### PR TITLE
[#x] 운영 환경 HTTPS 설정 추가

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,8 +11,19 @@ upstream backend {
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
+    listen [::]:80;
     server_name yamoyo.kr www.yamoyo.kr;
-    return 301 https://$host$request_uri;
+
+    location = /health {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "healthy\n";
+    }
+
+    # 그 외 요청만 HTTPS로 리다이렉트
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 # HTTPS 서버
@@ -25,10 +36,10 @@ server {
     ssl_certificate /etc/letsencrypt/live/yamoyo.kr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/yamoyo.kr/privkey.pem;
     
-    # SSL 설정
+    # SSL 설정 (Mozilla Intermediate)
     ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers HIGH:!aNULL:!MD5;
-    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
 
     # 기존 설정
     root /usr/share/nginx/html;
@@ -45,8 +56,8 @@ server {
     # Health
     location = /health {
         access_log off;
-        return 200 "healthy\n";
         add_header Content-Type text/plain;
+        return 200 "healthy\n";
     }
 
     # API
@@ -69,7 +80,7 @@ server {
     }
 
     # Static caching
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webmanifest|json)$ {
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webmanifest)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
         try_files $uri =404;


### PR DESCRIPTION
## 📄 PR 내용 요약

- 운영 환경 HTTPS 설정(SSL 인증서) 적용
- nginx 보안(Security) Header 설정 추가

## ✅ 작업 내용 상세

- 운영 환경에서 HTTPS 통신을 위한 SSL 인증 설정을 추가했습니다.
- 기본적인 보안 강화를 위해 nginx에 아래 Security Header를 적용했습니다.
   - X-Frame-Options
   - X-Content-Type-Options
   - Referrer-Policy

## 💬 참고 사항
x

## 📝 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거
