### PR TITLE
[#x] 에브리타임 시간표 파싱 기능

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,13 @@ export default function App() {
       <ModalRoot />
 
       <Routes>
+        {/* DEV: 개발용 라우트 (AuthGuard 우회) */}
+        <Route path="/dev/timeselect/:id" element={<TimeSelectPage />} />
+        <Route
+          path="/dev/timeselect/:id/everytime"
+          element={<EveryTimePage />}
+        />
+
         {/* 게스트 전용 (로그인 안 된 사람만) */}
         <Route element={<GuestGuard />}>
           <Route path="/" element={<LoginPage />} />

--- a/src/entities/everytime/api/everytime-api.ts
+++ b/src/entities/everytime/api/everytime-api.ts
@@ -1,0 +1,13 @@
+import { authClient } from '@/shared/api/auth/client';
+
+import type {
+  ParseEverytimeRequest,
+  ParseEverytimeResponse,
+} from './everytime-dto';
+
+/** 에브리타임 시간표 파싱 */
+export async function parseEverytime(
+  data: ParseEverytimeRequest,
+): Promise<ParseEverytimeResponse> {
+  return authClient.post<ParseEverytimeResponse>('/everytime/parse', data);
+}

--- a/src/entities/everytime/api/everytime-dto.ts
+++ b/src/entities/everytime/api/everytime-dto.ts
@@ -1,0 +1,20 @@
+/** 에브리타임 시간표 파싱 요청 */
+export interface ParseEverytimeRequest {
+  url: string;
+}
+
+/** 가용시간 데이터 (요일별 32슬롯, 30분 단위, 08:00~24:00) */
+export interface AvailabilityData {
+  sunday: boolean[];
+  monday: boolean[];
+  tuesday: boolean[];
+  wednesday: boolean[];
+  thursday: boolean[];
+  friday: boolean[];
+  saturday: boolean[];
+}
+
+/** 에브리타임 시간표 파싱 응답 */
+export interface ParseEverytimeResponse {
+  availability: AvailabilityData;
+}

--- a/src/entities/everytime/hooks/useParseEverytime.ts
+++ b/src/entities/everytime/hooks/useParseEverytime.ts
@@ -1,0 +1,20 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { parseEverytime } from '@/entities/everytime/api/everytime-api';
+import { useAvailabilityStore } from '@/entities/everytime/model/availability-store';
+
+export function useParseEverytime() {
+  const navigate = useNavigate();
+  const setImportedAvailability = useAvailabilityStore(
+    (state) => state.setImportedAvailability,
+  );
+
+  return useMutation({
+    mutationFn: (url: string) => parseEverytime({ url }),
+    onSuccess: (data) => {
+      setImportedAvailability(data.availability);
+      navigate(-1);
+    },
+  });
+}

--- a/src/entities/everytime/model/availability-store.ts
+++ b/src/entities/everytime/model/availability-store.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+
+import type { AvailabilityData } from '../api/everytime-dto';
+
+/** 7일 x 32슬롯 2차원 배열 형태 */
+export type AvailabilityGrid = boolean[][];
+
+/** API 응답(객체) → Grid(2차원 배열) 변환 (일~토 순서) */
+export function availabilityDataToGrid(
+  data: AvailabilityData,
+): AvailabilityGrid {
+  return [
+    data.sunday,
+    data.monday,
+    data.tuesday,
+    data.wednesday,
+    data.thursday,
+    data.friday,
+    data.saturday,
+  ];
+}
+
+/** Grid(2차원 배열) → API 요청(객체) 변환 */
+export function gridToAvailabilityData(
+  grid: AvailabilityGrid,
+): AvailabilityData {
+  return {
+    sunday: grid[0] ?? [],
+    monday: grid[1] ?? [],
+    tuesday: grid[2] ?? [],
+    wednesday: grid[3] ?? [],
+    thursday: grid[4] ?? [],
+    friday: grid[5] ?? [],
+    saturday: grid[6] ?? [],
+  };
+}
+
+interface AvailabilityState {
+  /** 에브리타임에서 불러온 가용시간 (null이면 불러온 적 없음) */
+  importedAvailability: AvailabilityGrid | null;
+  /** 에브리타임 가용시간 저장 */
+  setImportedAvailability: (data: AvailabilityData) => void;
+  /** 초기화 */
+  clearImportedAvailability: () => void;
+}
+
+export const useAvailabilityStore = create<AvailabilityState>((set) => ({
+  importedAvailability: null,
+
+  setImportedAvailability: (data) =>
+    set({ importedAvailability: availabilityDataToGrid(data) }),
+
+  clearImportedAvailability: () => set({ importedAvailability: null }),
+}));

--- a/src/pages/timeselect/everytime/index.tsx
+++ b/src/pages/timeselect/everytime/index.tsx
@@ -1,11 +1,19 @@
 import { useState } from 'react';
 
+import { useParseEverytime } from '@/entities/everytime/hooks/useParseEverytime';
 import BottomButton from '@/shared/ui/button/BottomButton';
 import TopBar from '@/shared/ui/header/TopBar';
 import TextField from '@/shared/ui/input/TextField';
 
 export default function EveryTimePage() {
   const [url, setUrl] = useState('');
+  const { mutate, isPending, isError } = useParseEverytime();
+
+  const handleSubmit = () => {
+    if (!url.trim()) return;
+    mutate(url.trim());
+  };
+
   return (
     <>
       <TopBar title="에브리타임 시간 등록" backIcon="arrow" />
@@ -20,6 +28,11 @@ export default function EveryTimePage() {
             onChange={setUrl}
             placeholder="링크 붙혀넣기"
           />
+          {isError && (
+            <p className="text-sm text-red-400">
+              시간표를 불러오는데 실패했습니다. URL을 확인해주세요.
+            </p>
+          )}
         </div>
 
         <div className="mb-4 flex flex-col gap-[66px] px-6">
@@ -35,7 +48,11 @@ export default function EveryTimePage() {
               alt="에브리타임 가이드"
             />
           </div>
-          <BottomButton text="등록" onClick={() => {}} />
+          <BottomButton
+            text={isPending ? '불러오는 중...' : '등록'}
+            onClick={handleSubmit}
+            disabled={isPending || !url.trim()}
+          />
         </div>
       </div>
     </>

--- a/src/pages/timeselect/index.tsx
+++ b/src/pages/timeselect/index.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { useAvailabilityStore } from '@/entities/everytime/model/availability-store';
 import BottomButton from '@/shared/ui/button/BottomButton';
 import TopBar from '@/shared/ui/header/TopBar';
 import { useModalStore } from '@/shared/ui/modal/model/modal-store';
@@ -28,10 +29,25 @@ export default function TimeSelectPage() {
   const openGuideModal = useModalStore((state) => state.openGuideModal);
   const closeModal = useModalStore((state) => state.closeModal);
 
+  const importedAvailability = useAvailabilityStore(
+    (state) => state.importedAvailability,
+  );
+  const clearImportedAvailability = useAvailabilityStore(
+    (state) => state.clearImportedAvailability,
+  );
+
   const [isEditMode, setIsEditMode] = useState(false);
   const [availability, setAvailability] = useState<boolean[][]>(
     createInitialAvailability,
   );
+
+  // 에브리타임에서 불러온 데이터가 있으면 적용
+  useEffect(() => {
+    if (importedAvailability) {
+      setAvailability(importedAvailability);
+      clearImportedAvailability();
+    }
+  }, [importedAvailability, clearImportedAvailability]);
 
   const handleReset = () => {
     setAvailability(createInitialAvailability());


### PR DESCRIPTION
## 📄 PR 내용 요약

- 에브리타임 시간표 파싱 기능

## ✅ 작업 내용 상세

- 기능을 위한 타입 선언

- 에브리타임 파싱을 위해 API 호출 작성 작성

- 로딩, 오류 처리를 위한 리액트 쿼리 코드 작성

- 임시 테스트를 위해 추가 라우팅 작성

## 📸 스크린샷 (선택사항)

<img width="386" height="912" alt="스크린샷 2026-02-05 15 12 12" src="https://github.com/user-attachments/assets/62aa299e-c56a-46af-ba95-560b72c5d409" />

<img width="386" height="912" alt="스크린샷 2026-02-05 15 12 15" src="https://github.com/user-attachments/assets/cca503f8-a291-42ed-b10b-1a6ec2365215" />

## 💬 참고 사항

- 따로 라우팅을 하나 더 만들어서 테스트하고 작업했습니다.

- 이제 타임셀렉트 페이지에서 가용시간이랑 선호시간대 제출하는 API 물려서 잘보내지는지 테스트 해봐야 될 것 같습니다 ~!

## 📝 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거
