### PR TITLE
[#x] env 관련 설정 빌드 시에 추가 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy Frontend to Production
 on:
   push:
     branches:
-      - main          # main 브랜치에 푸시될 때마다 실행
-  workflow_dispatch:  # 수동 실행 가능
+      - main # main 브랜치에 푸시될 때마다 실행
+  workflow_dispatch: # 수동 실행 가능
 
 jobs:
   deploy:
@@ -23,7 +23,9 @@ jobs:
       - name: Build and push Docker image
         run: |
           IMAGE="${{ secrets.DOCKER_USERNAME }}/yamoyo-nginx:prod"
-          docker build -t "$IMAGE" .
+          docker build \
+            --build-arg VITE_BASE_URL=${{ secrets.VITE_BASE_URL }} \
+            -t "$IMAGE" .
           docker push "$IMAGE"
 
       - name: Deploy to server
@@ -37,12 +39,12 @@ jobs:
             cd /srv/yamoyo
             docker compose -f docker-compose.prod.yml pull nginx
             docker compose -f docker-compose.prod.yml up -d nginx
-            
+
             echo "Waiting for nginx to start..."
             sleep 5
             docker compose -f docker-compose.prod.yml ps
             docker compose -f docker-compose.prod.yml logs --tail=50 nginx
-            
+
             docker image prune -f
 
       - name: Notify deployment success

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ FROM node:25-alpine AS builder
 
 WORKDIR /app
 
+# 빌드 인자 선언
+ARG VITE_BASE_URL
+RUN test -n "$VITE_BASE_URL" || (echo "Error: VITE_BASE_URL build-arg is required" >&2 && exit 1)
+ENV VITE_BASE_URL=${VITE_BASE_URL}
+
 # 의존성 설치
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
## 📄 PR 내용 요약

- 프론트엔드 배포 시 운영 환경 API 엔드포인트를 빌드 타임에 주입하도록 설정

## ✅ 작업 내용 상세

- **Dockerfile**: 빌드 시점에 `VITE_BASE_URL` 환경변수를 주입받도록 ARG/ENV 추가
- **deploy.yml**: Docker 빌드 시 `--build-arg`로 GitHub Secrets의 `VITE_BASE_URL` 전달
- 운영 환경에서 프론트엔드가 `https://yamoyo.kr/api` 엔드포인트로 API 요청하도록 설정

## 💬 참고 사항

- 빌드 타임에 환경변수가 번들에 포함되므로, 배포 후 변경 시 재빌드 필요
- main 배포 오류는 서버에 docker-compose.yml 파일이 없어서 생긴 문제 

## 📝 체크리스트
- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거