### PR TITLE
nginx.conf IPv6 설정 제거

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -11,7 +11,6 @@ upstream backend {
 # HTTP → HTTPS 리다이렉트
 server {
     listen 80;
-    listen [::]:80;
     server_name yamoyo.kr www.yamoyo.kr;
 
     location = /health {
@@ -29,7 +28,6 @@ server {
 # HTTPS 서버
 server {
     listen 443 ssl http2;
-    listen [::]:443 ssl http2;
     server_name yamoyo.kr www.yamoyo.kr;
 
     # SSL 인증서


### PR DESCRIPTION
## 📄 PR 내용 요약

- nginx.conf에서 IPv6 관련 설정 제거

## ✅ 작업 내용 상세

- 컨테이너에서 IPv6 문제로 인한 실행오류로 nginx.conf에서 관련 설정 제거했습니다.


## 💬 참고 사항

- x

## 📝 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거
