### PR TITLE
[#x] 팀룸 초대 페이지 -> 로그인 -> 초대 페이지로 복귀되지 않는 문제 재해결

### DIFF
--- a/src/entities/teamroom/hooks/useTeamRoom.ts
+++ b/src/entities/teamroom/hooks/useTeamRoom.ts
@@ -16,7 +16,6 @@ import type {
   CreateTeamRoomRequest,
   TeamRoomLifecycle,
 } from '@/entities/teamroom/api/teamroom-dto';
-import { YamoyoError } from '@/shared/api/base/http-error';
 
 /** 팀룸 목록 조회 */
 export function useTeamRoomList(lifecycle: TeamRoomLifecycle = 'ACTIVE') {
@@ -99,18 +98,6 @@ export function useJoinTeamRoom() {
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['teamrooms'] });
       navigate(`/teamroom/${data.teamRoomId}`, { replace: true });
-    },
-    onError: (e) => {
-      // 400/401/403에서만 redirect 저장
-      if (
-        e instanceof YamoyoError &&
-        (e.code === 400 || e.code === 401 || e.code === 403)
-      ) {
-        sessionStorage.setItem(
-          'redirectAfterLogin',
-          window.location.pathname + window.location.search,
-        );
-      }
     },
   });
 }

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useJoinTeamRoom } from '@/entities/teamroom/hooks/useTeamRoom';
 import { onAuthBlocked, resetAuthBlocked } from '@/shared/api/auth/event-bus';
 import { useAuthStore } from '@/shared/api/auth/store';
 
 export default function InvitePage() {
+  const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
@@ -16,6 +17,10 @@ export default function InvitePage() {
     const unsubscribe = onAuthBlocked('AUTH_EXPIRED', () => {
       useAuthStore.getState().clear();
 
+      sessionStorage.setItem(
+        'redirectAfterLogin',
+        location.pathname + location.search,
+      );
       // 플래그 초기화
       resetAuthBlocked(['AUTH_EXPIRED']);
 
@@ -23,7 +28,7 @@ export default function InvitePage() {
     });
 
     return unsubscribe;
-  }, [navigate]);
+  }, [navigate, location]);
 
   const handleJoin = () => {
     if (!token) {


### PR DESCRIPTION
## 📄 PR 내용 요약

- [이전 PR](https://github.com/yamoyo/yamoyo_FE/pull/93)에서 생기던 문제 다시 발생 -> 재해결

## ✅ 작업 내용 상세

- 토큰만료 시 리다이렉트 될 때 세션스토리지에 해당 값이 정상적으로 실리지 않았거나
- 리다이렉트 링크를 불러오는 코드를 잘못 작성한 것 같습니다..
- 두 문제를 모두 해결하기 위해, `invite` 페이지에 내부에 `AUTH_EXPIRED` 이벤트 동작 핸들러 안에 리다이렉트 링크를 저장하도록 하였습니다.
- `invite` 페이지에 내부에 있다보니 원래 하셨던 방법인 `useLocation`를 통해 리다이렉트를 불러올 수 있고, 좀 더 역할이 명확해 보이도록? 코드 구성이 되어서 좋은 것 같습니다!

## 💬 참고 사항

- 배포 환경에서 테스트 꼭 필요 ,,

## 📝 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 로컬 빌드/테스트 통과
- [x] 불필요한 코드/주석 제거
